### PR TITLE
5.x

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ ADD nginx.conf.tpl /etc/nginx/nginx.conf.tpl
 ADD ./run.sh ./run.sh
 
 # kopf
-ENV KOPF_VERSION 2.0.1
-RUN curl -s -L "https://github.com/lmenezes/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz" | \
+ENV KOPF_VERSION 5.0.0
+RUN curl -s -L "https://github.com/g6n/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz" | \
     tar xz -C /tmp && mv "/tmp/elasticsearch-kopf-${KOPF_VERSION}" /kopf
 
 # logs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.9.4
 
 # upgrade
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    apt-get upgrade -y --force-yes && \
     apt-get install -y --force-yes --no-install-recommends python-pip curl && \
     rm -rf /var/lib/apt/lists/* && \
     pip install envtpl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM nginx:1.9.4
 # upgrade
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends python-pip curl && \
+    apt-get install -y --force-yes --no-install-recommends python-pip curl && \
     rm -rf /var/lib/apt/lists/* && \
     pip install envtpl
 


### PR DESCRIPTION
Made a few adjustments in the 5.x branch to make a working version.
+Had to compile the 5.0.0 version and host it on my own repo:
https://github.com/g6n/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz

Still has a small bug not displaying not types correctly (all are displayed as possible master)
